### PR TITLE
Fix operator in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _*For Laravel >= 5.5*_ - Via Composer
 $ composer require mad-web/laravel-initializer
 ```
 
-_*For Laravel >= 5.5*_ - Now add the service provider in config/app.php file:
+_*For Laravel < 5.5*_ - Now add the service provider in config/app.php file:
 ```php
 'providers' => [
     // ...


### PR DESCRIPTION
I believe it's required for Laravel < 5.5. For Laravel 5.5 it seems auto discovery is used