### PR TITLE
Removed 'optimize' command from install config.

### DIFF
--- a/stubs/install-config.stub
+++ b/stubs/install-config.stub
@@ -17,7 +17,6 @@ class Install
             ->external('npm', 'run', 'production')
             ->artisan('route:cache')
             ->artisan('config:cache')
-            ->artisan('optimize')
             ->external('composer', 'dump-autoload', '--optimize');
     }
 


### PR DESCRIPTION
Because it's deprecated in Laravel 5.6