### PR TITLE
Fixed errors message.

### DIFF
--- a/src/Actions/External.php
+++ b/src/Actions/External.php
@@ -54,7 +54,7 @@ class External extends Action
             }
         } : null);
 
-        $error = $Process->getErrorOutput();
+        $error = empty($Process->getErrorOutput()) ? $Process->getOutput() : $Process->getErrorOutput();
         $exitCode = $Process->getExitCode();
 
         if ($error and $exitCode > 0) {

--- a/src/Console/Commands/AbstractInitializeCommand.php
+++ b/src/Console/Commands/AbstractInitializeCommand.php
@@ -34,6 +34,14 @@ abstract class AbstractInitializeCommand extends Command
 
         $this->alert($this->title().' started');
 
+        if (is_array($env)) {
+
+            $this->error('Config not found in cache.');
+            $this->error('$ php artisan config:cache');
+
+            return 1;
+        }
+
         $result = $initializerInstance
             ->{$this->option('root') ? $env.'Root' : $env}
             ($container->makeWith(Run::class, ['artisanCommand' => $this]));


### PR DESCRIPTION
Signed-off-by: Dmitry Mazurov <dimabzz@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed errors message.

## Motivation and context

These changes fix the error if after installation they did not execute config: cache. It also corrects an error if getErrorOutput is empty, but there is an error.

## How has this been tested?

Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

## Screenshots (if appropriate)
<img width="1014" alt="Снимок экрана 2020-01-20 в 14 49 55" src="https://user-images.githubusercontent.com/8027583/72724430-537b2780-3b94-11ea-87be-a5ff9184ad1d.png">
<img width="764" alt="Снимок экрана 2020-01-20 в 14 45 11" src="https://user-images.githubusercontent.com/8027583/72724431-537b2780-3b94-11ea-8931-f278385a9f16.png">

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
