### PR TITLE
Fixed bug if getErrorOutput () is empty, but $ exitCode> 0

### DIFF
--- a/src/Actions/External.php
+++ b/src/Actions/External.php
@@ -54,7 +54,7 @@ class External extends Action
             }
         } : null);
 
-        $error = $Process->getErrorOutput();
+        $error = empty($Process->getErrorOutput()) ? $Process->getOutput() : $Process->getErrorOutput();
         $exitCode = $Process->getExitCode();
 
         if ($error and $exitCode > 0) {

--- a/tests/ExternalRunnerCommandTest.php
+++ b/tests/ExternalRunnerCommandTest.php
@@ -57,4 +57,17 @@ class ExternalRunnerCommandTest extends RunnerCommandsTestCase
 
         $this->assertErrorAppeared('invalid-command', RuntimeException::class);
     }
+
+    /**
+     * @test
+     * @dataProvider initCommandsSet
+     */
+    public function external_supervisorctl($command)
+    {
+        $this->declareCommands(function (Run $run) {
+            $run->external('supervisorctl', 'status');
+        }, $command);
+
+        $this->assertErrorAppeared('supervisorctl', RuntimeException::class);
+    }
 }


### PR DESCRIPTION
Signed-off-by: Dmitry Mazurov <dimabzz@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed bug if getErrorOutput () is empty, but $ exitCode> 0

## Motivation and context

If the command fails and the error code is greater than 0, and the result $ Process-> getErrorOutput () is empty, an error will appear. This is manifested if you run the program from outside the root.

## How has this been tested?

Ubuntu 18.04
PHP 7.2.24
Laravel 6.11.0

## Screenshots (if appropriate)
<img width="1014" alt="Снимок экрана 2020-01-20 в 14 49 55" src="https://user-images.githubusercontent.com/8027583/72734571-12424200-3bab-11ea-8d7a-dc1f35b2d455.png">

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
