### PR TITLE
[HOTFIX] errorMessage can return NULL as well

### DIFF
--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -43,7 +43,7 @@ abstract class Action
         return $this->failed;
     }
 
-    public function errorMessage(): string
+    public function errorMessage():? string
     {
         return $this->errorMessage;
     }


### PR DESCRIPTION
## Description

Fixes #17 

This is important if Update.php contains `$run->artisan('down');`: When app is already down $errorMessage remains NULL and app:update breaks with an exception.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- [x] My pull request addresses exactly one patch/feature.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.
